### PR TITLE
Mapper: allow optional array with block

### DIFF
--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
@@ -90,11 +90,11 @@ class ReeMapper::MapperFactory
     @mapper.add_field(type, field_name, optional: optional, **opts)
   end
 
-  contract(Symbol, Any, Ksplat[RestKeys => Any] => Nilor[ReeMapper::Field])
-  def array?(field_name, each:, **opts)
+  contract(Symbol, Kwargs[each: Nilor[ReeMapper::Field]], Ksplat[RestKeys => Any], Optblock => Nilor[ReeMapper::Field])
+  def array?(field_name, each: nil, **opts, &blk)
     raise ArgumentError if opts.key?(:optional)
 
-    array(field_name, each: each, optional: true, **opts)
+    array(field_name, each: each, optional: true, **opts, &blk)
   end
 
   contract(Symbol, Kwargs[key: Nilor[Symbol]], Ksplat[RestKeys => Any], Block => nil)

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/spec/ree_mapper/types/type_options_spec.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/spec/ree_mapper/types/type_options_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe 'ReeMapper::MapperFactory type options' do
         integer? :opt_number
         integer :opt_number_long, optional: true
         array? :opt_array, each: integer
+        array? :opt_array_with_blk do
+          integer :id
+        end
       }
     }
 
@@ -56,6 +59,10 @@ RSpec.describe 'ReeMapper::MapperFactory type options' do
 
     it {
       expect(mapper.cast({ number: 1, opt_array: [1] })).to eq({ number: 1, opt_array: [1] })
+    }
+
+    it {
+      expect(mapper.cast({ number: 1, opt_array_with_blk: [{ id: 1 }] })).to eq({ number: 1, opt_array_with_blk: [{ id: 1 }] })
     }
   end
 


### PR DESCRIPTION
Allow mapper with optional array with block

```ruby
mapper_factory.call do
  array? :opt_ary_with_blk do
    integer :id
  end
end
```