### PR TITLE
Multiple types registration with same name

### DIFF
--- a/ree_lib/Gemfile.lock
+++ b/ree_lib/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     msgpack (1.6.0)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     oj (3.13.23)

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper.rb
@@ -160,7 +160,7 @@ Create `mapper_factory.rb` file to declare `MapperFactory` class.
         build_mapper_strategy(method: :db_load,   dto: Object)
       ])
 
-      mapper_factory.register(:cart_user, user_caster)
+      mapper_factory.register_mapper(:cart_user, user_caster)
 
       mapper_factory
     end

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/functions/build_mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/functions/build_mapper_factory.rb
@@ -18,13 +18,13 @@ class ReeMapper::BuildMapperFactory
       @strategies = strategies
     }
 
-    klass.register(:bool, Mapper.build(strategies, ReeMapper::Bool.new))
-    klass.register(:date_time, Mapper.build(strategies, ReeMapper::DateTime.new))
-    klass.register(:time, Mapper.build(strategies, ReeMapper::Time.new))
-    klass.register(:date, Mapper.build(strategies, ReeMapper::Date.new))
-    klass.register(:float, Mapper.build(strategies, ReeMapper::Float.new))
-    klass.register(:integer, Mapper.build(strategies, ReeMapper::Integer.new))
-    klass.register(:string, Mapper.build(strategies, ReeMapper::String.new))
+    klass.register_type(:bool, ReeMapper::Bool.new)
+    klass.register_type(:date_time, ReeMapper::DateTime.new)
+    klass.register_type(:time, ReeMapper::Time.new)
+    klass.register_type(:date, ReeMapper::Date.new)
+    klass.register_type(:float, ReeMapper::Float.new)
+    klass.register_type(:integer, ReeMapper::Integer.new)
+    klass.register_type(:string, ReeMapper::String.new)
 
     klass
   end

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper.rb
@@ -7,7 +7,7 @@ class ReeMapper::Mapper
       strategies.each do |strategy|
         method = strategy.method
         next if type.respond_to?(method)
-        raise ReeMapper::UnsupportedTypeError, "type #{type.name} should implement method `#{method}`"
+        raise ReeMapper::UnsupportedTypeError, "type #{type.inspect} should implement method `#{method}`"
       end
     end
 

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper.rb
@@ -113,7 +113,7 @@ class ReeMapper::Mapper
 
   contract(Symbol => Class).throws(ArgumentError)
   def dto(strategy_method)
-    strategy = strategies.detect { _1.method == strategy_method }
+    strategy = find_strategy(strategy_method)
     raise ArgumentError, "there is no :#{strategy_method} strategy" unless strategy
     strategy.dto
   end
@@ -123,5 +123,10 @@ class ReeMapper::Mapper
     raise ReeMapper::ArgumentError, "mapper should contain at least one field" if fields.empty?
     strategies.each { _1.prepare_dto(fields.keys) }
     nil
+  end
+
+  contract(Symbol => Nilor[ReeMapper::MapperStrategy])
+  def find_strategy(strategy_method)
+    strategies.detect { _1.method == strategy_method }
   end
 end

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
@@ -22,7 +22,6 @@ class ReeMapper::MapperFactory
   def self.register(name, type)
     raise ArgumentError, "name of mapper type should not end with `?`" if name.to_s.end_with?('?')
 
-    name_types = types[name]
     defined_strategy_method = types[name]&.flat_map(&:strategies)&.map(&:method)&.detect { type.find_strategy(_1) }
     raise ArgumentError, "type :#{name} with `#{defined_strategy_method}` strategy already registered" if defined_strategy_method
     raise ArgumentError, "method :#{name} already defined" if !types.key?(name) && method_defined?(name)

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
@@ -5,17 +5,17 @@ class ReeMapper::MapperFactory
     attr_reader :types, :strategies
   end
 
-  contract(Symbol, Any => Class).throws(ArgumentError)
-  def self.register_type(name, object_type)
+  contract(Symbol, ReeMapper::AbstractType, Kwargs[strategies: ArrayOf[ReeMapper::MapperStrategy]] => Class)
+  def self.register_type(name, object_type, strategies: self.strategies)
     register(
       name,
       ReeMapper::Mapper.build(strategies, object_type)
     )
   end
 
-  contract(Symbol, Any => Class).throws(ArgumentError)
+  contract(Symbol, ReeMapper::Mapper => Class).throws(ArgumentError)
   def self.register(name, type)
-    raise ArgumentError, "name of mapper type should not include `?`" if name.to_s.end_with?('?')
+    raise ArgumentError, "name of mapper type should not end with `?`" if name.to_s.end_with?('?')
     raise ArgumentError, "type :#{name} already registered" if types.key?(name)
     raise ArgumentError, "method :#{name} already defined" if method_defined?(name)
 

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
@@ -22,7 +22,7 @@ class ReeMapper::MapperFactory
   def self.register(name, type)
     raise ArgumentError, "name of mapper type should not end with `?`" if name.to_s.end_with?('?')
 
-    defined_strategy_method = types[name]&.flat_map(&:strategies)&.map(&:method)&.detect { type.find_strategy(_1) }
+    defined_strategy_method = types[name]&.flat_map(&:strategy_methods)&.detect { type.find_strategy(_1) }
     raise ArgumentError, "type :#{name} with `#{defined_strategy_method}` strategy already registered" if defined_strategy_method
     raise ArgumentError, "method :#{name} already defined" if !types.key?(name) && method_defined?(name)
 

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
@@ -12,14 +12,14 @@ class ReeMapper::MapperFactory
 
   contract(Symbol, ReeMapper::AbstractType, Kwargs[strategies: ArrayOf[ReeMapper::MapperStrategy]] => Class)
   def self.register_type(name, object_type, strategies: self.strategies)
-    register(
+    register_mapper(
       name,
       ReeMapper::Mapper.build(strategies, object_type)
     )
   end
 
   contract(Symbol, ReeMapper::Mapper => Class).throws(ArgumentError)
-  def self.register(name, type)
+  def self.register_mapper(name, type)
     raise ArgumentError, "name of mapper type should not end with `?`" if name.to_s.end_with?('?')
 
     defined_strategy_method = types[name]&.flat_map(&:strategy_methods)&.detect { type.find_strategy(_1) }

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory.rb
@@ -5,6 +5,11 @@ class ReeMapper::MapperFactory
     attr_reader :types, :strategies
   end
 
+  contract(Symbol => Nilor[ReeMapper::MapperStrategy])
+  def self.find_strategy(strategy_method)
+    strategies.detect { _1.method == strategy_method }
+  end
+
   contract(Symbol, ReeMapper::AbstractType, Kwargs[strategies: ArrayOf[ReeMapper::MapperStrategy]] => Class)
   def self.register_type(name, object_type, strategies: self.strategies)
     register(
@@ -16,24 +21,27 @@ class ReeMapper::MapperFactory
   contract(Symbol, ReeMapper::Mapper => Class).throws(ArgumentError)
   def self.register(name, type)
     raise ArgumentError, "name of mapper type should not end with `?`" if name.to_s.end_with?('?')
-    raise ArgumentError, "type :#{name} already registered" if types.key?(name)
-    raise ArgumentError, "method :#{name} already defined" if method_defined?(name)
+
+    name_types = types[name]
+    defined_strategy_method = types[name]&.flat_map(&:strategies)&.map(&:method)&.detect { type.find_strategy(_1) }
+    raise ArgumentError, "type :#{name} with `#{defined_strategy_method}` strategy already registered" if defined_strategy_method
+    raise ArgumentError, "method :#{name} already defined" if !types.key?(name) && method_defined?(name)
 
     type = type.dup
     type.name = name
     type.freeze
-    types[name] = type
+    types[name] ||= []
+    types[name] << type
 
     class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
       def #{name}(field_name = nil, optional: false, **opts)
         raise ReeMapper::Error, "invalid DSL usage" unless @mapper
         raise ArgumentError, "array item can't be optional" if field_name.nil? && optional
 
-        type = self.class.types.fetch(:#{name})
+        type = self.class.types.fetch(:#{name}).detect { (@mapper.strategy_methods - _1.strategy_methods).empty? }
 
-        @mapper.strategy_methods.each do |method|
-          next if type.respond_to?(method)
-          raise ReeMapper::UnsupportedTypeError, "type :#{name} should implement method `\#{method}`"
+        unless type
+          raise ReeMapper::UnsupportedTypeError, "type :#{name} should implement `\#{@mapper.strategy_methods.join(', ')}`"
         end
 
         return ReeMapper::Field.new(type, optional: optional, **opts) unless field_name

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory_proxy.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory_proxy.rb
@@ -36,7 +36,7 @@ class ReeMapper::MapperFactoryProxy
     mapper_factory.new(mapper).instance_exec(&blk)
     mapper.prepare_dto
 
-    mapper_factory.register(register_as, mapper) if register_as
+    mapper_factory.register_mapper(register_as, mapper) if register_as
 
     after_build&.call(mapper)
 

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory_proxy.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/mapper_factory_proxy.rb
@@ -22,7 +22,7 @@ class ReeMapper::MapperFactoryProxy
     if strategy_or_method.is_a?(ReeMapper::MapperStrategy)
       strategy = strategy_or_method
     else
-      strategy = mapper_factory.strategies.detect { _1.method == strategy_or_method }
+      strategy = mapper_factory.find_strategy(strategy_or_method)
       raise ArgumentError, "MapperFactory strategy :#{strategy_or_method} not found" unless strategy
       strategy = strategy.dup
       strategy.dto = dto if dto

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/types/abstract_type.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/package/ree_mapper/types/abstract_type.rb
@@ -1,17 +1,2 @@
 class ReeMapper::AbstractType
-  def serialize(value, name:, role: nil)
-    raise NotImplementedError
-  end
-
-  def cast(value, name:, role: nil)
-    raise NotImplementedError
-  end
-
-  def db_dump(value, name:, role: nil)
-    raise NotImplementedError
-  end
-
-  def db_load(value, name:, role: nil)
-    raise NotImplementedError
-  end
 end

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/spec/ree_mapper/mapper_factory_spec.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/spec/ree_mapper/mapper_factory_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe ReeMapper::MapperFactory do
     }
   end
 
-  describe '.register' do
+  describe '.register_mapper' do
     let(:serializer) { mapper_factory.call.use(:serialize) { integer :id } }
 
     it {
-      mapper_factory.register(:new_type, serializer)
+      mapper_factory.register_mapper(:new_type, serializer)
 
       expect(
         mapper_factory.call.use(:serialize) { new_type :val }.serialize({ val: { id: 1 } })
@@ -46,8 +46,8 @@ RSpec.describe ReeMapper::MapperFactory do
     it 'allow to register caster and serializer with same name' do
       caster = mapper_factory.call.use(:cast) { string :name }
 
-      mapper_factory.register(:new_type, serializer)
-      mapper_factory.register(:new_type, caster)
+      mapper_factory.register_mapper(:new_type, serializer)
+      mapper_factory.register_mapper(:new_type, caster)
 
       expect(
         mapper_factory.call.use(:serialize) { new_type :val }.serialize({ val: { id: 1 } })
@@ -59,22 +59,22 @@ RSpec.describe ReeMapper::MapperFactory do
     end
 
     it 'raise an error if the mapper is already registered' do
-      mapper_factory.register(:new_type, serializer)
+      mapper_factory.register_mapper(:new_type, serializer)
 
       expect {
-        mapper_factory.register(:new_type, serializer)
+        mapper_factory.register_mapper(:new_type, serializer)
       }.to raise_error(ArgumentError, 'type :new_type with `serialize` strategy already registered')
     end
 
     it 'raise an error if the mapper name is ended by ?' do
       expect {
-        mapper_factory.register(:new_type?, serializer)
+        mapper_factory.register_mapper(:new_type?, serializer)
       }.to raise_error(ArgumentError, 'name of mapper type should not end with `?`')
     end
 
     it 'raise an error if the mapper name is reserved' do
       expect {
-        mapper_factory.register(:array, serializer)
+        mapper_factory.register_mapper(:array, serializer)
       }.to raise_error(ArgumentError, 'method :array already defined')
     end
   end
@@ -93,7 +93,7 @@ RSpec.describe ReeMapper::MapperFactory do
         integer :my_field
       end
 
-      mapper_factory.register(:new_type, serializer)
+      mapper_factory.register_mapper(:new_type, serializer)
 
       expect {
         mapper_factory.call.use(:cast) do

--- a/ree_lib/lib/ree_lib/packages/ree_mapper/spec/ree_mapper/mapper_spec.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_mapper/spec/ree_mapper/mapper_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ReeMapper::Mapper do
       )
     }
 
-    it { 
+    it {
       expect(mapper.cast({ my_field: 1, hsh: { nested_field: 1 } })).to be_a(Struct)
     }
   end
@@ -164,6 +164,30 @@ RSpec.describe ReeMapper::Mapper do
 
     it {
       expect { mapper.dto(:db_dump) }.to raise_error(ArgumentError, "there is no :db_dump strategy")
+    }
+  end
+
+  describe '#find_strategy' do
+    let(:mapper_factory) {
+      build_mapper_factory(
+        strategies: [
+          build_mapper_strategy(method: :cast),
+          build_mapper_strategy(method: :serialize),
+        ]
+      )
+    }
+    let(:mapper) {
+      mapper_factory.call.use(:cast) do
+        integer :my_field
+      end
+    }
+
+    it {
+      expect(mapper.find_strategy(:cast)).to be_a(ReeMapper::MapperStrategy)
+    }
+
+    it {
+      expect(mapper.find_strategy(:serialize)).to be_nil
     }
   end
 end

--- a/ree_lib/lib/ree_lib/packages/ree_swagger/spec/functions/build_serializer_schema_spec.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_swagger/spec/functions/build_serializer_schema_spec.rb
@@ -11,16 +11,13 @@ RSpec.describe :build_serializer_schema do
 
     build_mapper_factory(
       strategies: strategies
-    ).register(
+    ).register_type(
       :unregistered_type,
-      ReeMapper::Mapper.build(
-        strategies,
-        Class.new(ReeMapper::AbstractType) do
-          def serialize(val, role: nil)
-            val
-          end
-        end.new
-      )
+      Class.new(ReeMapper::AbstractType) do
+        def serialize(val, role: nil)
+          val
+        end
+      end.new
     )
   }
 
@@ -118,10 +115,10 @@ RSpec.describe :build_serializer_schema do
           test_unregistered_type: {},
           partial_value: {
             type: 'object',
-            properties: { 
+            properties: {
               nested_partial_value: {
                 type: 'object',
-                properties: { 
+                properties: {
                   included: { type: 'string' }
                 }
               }

--- a/ree_lib/lib/ree_lib/packages/ree_swagger/spec/functions/register_type_spec.rb
+++ b/ree_lib/lib/ree_lib/packages/ree_swagger/spec/functions/register_type_spec.rb
@@ -15,13 +15,8 @@ RSpec.describe :register_type do
       build_mapper_strategy(method: :serialize, dto: Hash),
     ]
 
-    build_mapper_factory(strategies: strategies).register(
-      :my_type,
-      ReeMapper::Mapper.build(
-        strategies,
-        ReeSwagger::MyType.new
-      )
-    )
+    build_mapper_factory(strategies: strategies)
+      .register_type(:my_type, ReeSwagger::MyType.new)
   }
 
   let(:mapper) {


### PR DESCRIPTION
Allow to register caster and serializer with same name.
Type registration permit strategies.